### PR TITLE
Remove 0.0 when there is no trade, sams as monthly_heatmap_detailedview

### DIFF
--- a/quantstats_lumi/_plotting/wrappers.py
+++ b/quantstats_lumi/_plotting/wrappers.py
@@ -935,6 +935,7 @@ def monthly_heatmap(
     cmap = "gray" if grayscale else "RdYlGn"
 
     returns = _stats.monthly_returns(returns, eoy=eoy, compounded=compounded) * 100
+    mask = returns.map(lambda x: x == 0)
 
     fig_height = len(returns) / 2.5
 
@@ -983,6 +984,7 @@ def monthly_heatmap(
             cbar=cbar,
             cmap=cmap,
             cbar_kws={"format": "%.0f%%"},
+            mask=mask,
         )
     else:
         ax.set_title(
@@ -1005,6 +1007,7 @@ def monthly_heatmap(
             cbar=cbar,
             cmap=cmap,
             cbar_kws={"format": "%.0f%%"},
+            mask=mask,
         )
     # _sns.set(font_scale=1)
 
@@ -1016,6 +1019,8 @@ def monthly_heatmap(
     ax.tick_params(colors="#808080")
     _plt.xticks(rotation=0, fontsize=annot_size * 1.2)
     _plt.yticks(rotation=0, fontsize=annot_size * 1.2)
+
+    plt.grid(False)
 
     try:
         _plt.subplots_adjust(hspace=0, bottom=0, top=1)


### PR DESCRIPTION
Changes:
- Removed 0.0 when there is no trade in the monthly_heatmap function.
- Added a mask to filter out 0.0 values.
- Remove grid

These changes align the behavior of the monthly_heatmap function with the monthly_heatmap_detailedview function.

Here is sample figure with BTC's close data. 
![image](https://github.com/user-attachments/assets/10daf781-35bd-4e65-9499-0dba8e4f0c47)

