### PR TITLE
plot_timeseries does not handle returns type properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Icon
 QuantStats_Lumi.egg-info/*
 test_tearsheet.html
 test_tearsheet_parameters.html
+.venv/**

--- a/quantstats_lumi/reports.py
+++ b/quantstats_lumi/reports.py
@@ -24,6 +24,7 @@ from datetime import datetime as _dt
 from io import StringIO
 from math import ceil as _ceil
 from math import sqrt as _sqrt
+from typing import Optional, Union
 
 import numpy as _np
 import pandas as _pd
@@ -586,8 +587,8 @@ def html(
 
 
 def full(
-    returns,
-    benchmark=None,
+    returns:Union[_pd.Series,_pd.DataFrame],
+    benchmark:Optional[_pd.Series]=None,
     rf=0.0,
     grayscale=False,
     figsize=(8, 5),
@@ -599,6 +600,11 @@ def full(
 ):
     """calculates and plots full performance metrics"""
 
+    if isinstance(returns, (_pd.Series,_pd.DataFrame)) is False:
+        raise ValueError(f"returns must be a pandas Series or DataFrame, got {type(returns)}")
+    if benchmark is not None and isinstance(benchmark, _pd.Series) is False:
+        raise ValueError(f"benchmark must be None or pandas Series, got {type(benchmark)}")
+    
     # prepare timeseries
     if match_dates:
         returns = returns.dropna()


### PR DESCRIPTION
This Pull requests adresses https://github.com/Lumiwealth/quantstats_lumi/issues/61

Summary of changes

1. added proper pd.DataFrame support to plot_timeseries
2. added annotations to plot_timeseries and reports.full
3. added returns and benchmark type checking to plot_timeseries and reports.full

Test evidences 

* brefore fix [test_311_error.ipynb](https://github.com/SergeyHein/quantstats_lumi/blob/wip-issues-61/test_311_error.ipynb)
* after fix [test_311_error.ipynb](https://github.com/SergeyHein/quantstats_lumi/blob/wip-issues-61/test_311_fixed.ipynb)


To keep scope of the fix limited   behavior of `reports.full` when strategy / returnes are passed as `pd.DataFrame` is kept as-is. Subject to a further bug report / inverstigation

Any questions / suggestions let me know.
Sergey

