### PR TITLE
Fix the error in reports.full()

### DIFF
--- a/quantstats_lumi/_plotting/core.py
+++ b/quantstats_lumi/_plotting/core.py
@@ -355,11 +355,11 @@ def plot_timeseries(
     _plt.yscale("symlog" if log_scale else "linear")
 
     # Set y-axis limits to avoid blank space at the bottom and top
-    min_val = returns.min()
-    max_val = returns.max()
+    min_val = float(returns.min())
+    max_val = float(returns.max())
     if benchmark is not None:
-        min_val = min(min_val, benchmark.min())
-        max_val = max(max_val, benchmark.max())
+        min_val = min(min_val, float(benchmark.min()))
+        max_val = max(max_val, float(benchmark.max()))
     ax.set_ylim(bottom=min_val, top=max_val)
 
     if percent:


### PR DESCRIPTION
This Pull requests Fixes #55 

Changes:
- Cast float to "returns.min()" and to "benchmark.min()"

As described in the issue, line 361 in core.py was comparing a _<class 'numpy.float64'>_ with a _<class 'pandas.core.series.Series'>_, which was causing an error.

Simply casting a float to both variables ensures that the comparison is made between equal types and fixes the issue without breaking the reports.html() function mentioned in the issue.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Convert minimum and maximum return and benchmark values to floats in `plot_timeseries()` within `core.py` to fix error in `reports.full()`.

### Why are these changes being made?

The error was caused by incompatible data types used for y-axis limit calculations; converting these values to floats ensures compatibility and accuracy in plotting. This change addresses the issue without affecting related functionalities, providing a simple and effective solution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->