### PR TITLE
benchmark bug fix

### DIFF
--- a/quantstats_lumi/_plotting/core.py
+++ b/quantstats_lumi/_plotting/core.py
@@ -480,10 +480,11 @@ def plot_histogram(
         if len(returns.columns) > 1:
             alpha = 0.5
 
+    fix_instance = lambda x: x[x.columns[0]] if isinstance(x, _pd.DataFrame) else x
     if benchmark is not None:
         if isinstance(returns, _pd.Series):
             combined_returns = (
-                benchmark.to_frame()
+                fix_instance(benchmark).to_frame()
                 .join(returns.to_frame())
                 .stack()
                 .reset_index()
@@ -491,7 +492,7 @@ def plot_histogram(
             )
         elif isinstance(returns, _pd.DataFrame):
             combined_returns = (
-                benchmark.to_frame()
+                fix_instance(benchmark).to_frame()
                 .join(returns)
                 .stack()
                 .reset_index()

--- a/quantstats_lumi/reports.py
+++ b/quantstats_lumi/reports.py
@@ -51,10 +51,8 @@ def _get_trading_periods(periods_per_year=365):
 
 def _match_dates(returns, benchmark):
     """match dates of returns and benchmark"""
-    if isinstance(returns, _pd.DataFrame):
-        loc = max(returns[returns.columns[0]].ne(0).idxmax(), benchmark.ne(0).idxmax())
-    else:
-        loc = max(returns.ne(0).idxmax(), benchmark.ne(0).idxmax())
+    fix_instance = lambda x: x.columns[0] if isinstance(x, _pd.DataFrame) else x
+    loc = max(fix_instance(returns).ne(0).idxmax(), fix_instance(benchmark).ne(0).idxmax())
     returns = returns.loc[loc:]
     benchmark = benchmark.loc[loc:]
 


### PR DESCRIPTION
Quick fix for issue #69.

For some reason benchmark variable can be dataframe now, probably because of the changes in the yfinance library. I did a quick fix by selecting it's first column. Not sure how general this fix is, but I suppose if there is only one benchmark, it should be fine.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a lambda function `fix_instance` to uniformly handle `_pd.DataFrame` and `_pd.Series` types in the functions responsible for combining returns and benchmarks and for matching their dates.

### Why are these changes being made?

The existing code did not correctly handle instances where the benchmark or returns were provided as a DataFrame, causing failures in these operations. By introducing a lambda function to extract the first column of a DataFrame (or directly use a Series), this change ensures compatibility and seamless operation when handling either data type, ultimately fixing existing bugs in the plotting and report generation process.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->