### PR TITLE
fix years calculation in cagr() and removing the "periods" parameter

### DIFF
--- a/quantstats_lumi/reports.py
+++ b/quantstats_lumi/reports.py
@@ -205,7 +205,6 @@ def html(
     # Add the total return to the template
     tpl = tpl.replace("{{total_return}}", total_return)
 
-
     # Max Drawdown #
     # Get the value of the "Strategy" column where the "Mteric" column is "Max Drawdown"
     max_drawdown = mtrx.loc["Max Drawdown", strategy_title]
@@ -235,7 +234,6 @@ def html(
     sortino = mtrx.loc["Sortino", strategy_title]
     # Add the Sharpe to the template
     tpl = tpl.replace("{{sortino}}", sortino)
-
 
     if isinstance(returns, _pd.DataFrame):
         num_cols = len(returns.columns)
@@ -738,6 +736,7 @@ def full(
         active=active,
     )
 
+
 def basic(
     returns,
     benchmark=None,
@@ -820,6 +819,7 @@ def basic(
         active=active,
     )
 
+
 def parameters_section(parameters):
     """returns a formatted section for strategy parameters"""
     if parameters is None:
@@ -846,6 +846,7 @@ def parameters_section(parameters):
     """
 
     return tpl
+
 
 def metrics(
     returns,
@@ -957,11 +958,13 @@ def metrics(
     metrics["~"] = blank
 
     if compounded:
-        metrics["Total Return"] = (_stats.comp(df) * pct).map("{:,.0f}%".format)  # No decimals for readability as it is a large number
+        metrics["Total Return"] = (_stats.comp(df) * pct).map(
+            "{:,.0f}%".format
+        )  # No decimals for readability as it is a large number
     else:
         metrics["Total Return"] = (df.sum() * pct).map("{:,.2f}%".format)
 
-    metrics["CAGR% (Annual Return) "] = _stats.cagr(df, rf, compounded, win_year) * pct
+    metrics["CAGR% (Annual Return) "] = _stats.cagr(df, rf, compounded) * pct
 
     metrics["~~~~~~~~~~~~~~"] = blank
 
@@ -969,7 +972,9 @@ def metrics(
     metrics["RoMaD"] = _stats.romad(df, win_year, True)
 
     if benchmark is not None:
-        metrics["Corr to Benchmark "] = _stats.benchmark_correlation(df, benchmark, True)
+        metrics["Corr to Benchmark "] = _stats.benchmark_correlation(
+            df, benchmark, True
+        )
     metrics["Prob. Sharpe Ratio %"] = (
         _stats.probabilistic_sharpe_ratio(df, rf, win_year, False) * pct
     )
@@ -1096,21 +1101,15 @@ def metrics(
     metrics["1Y %"] = comp_func(df[df.index >= d]) * pct
 
     d = today - relativedelta(months=35)
-    metrics["3Y (ann.) %"] = (
-        _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
-    )
+    metrics["3Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
 
     d = today - relativedelta(months=59)
-    metrics["5Y (ann.) %"] = (
-        _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
-    )
+    metrics["5Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
 
     d = today - relativedelta(years=10)
-    metrics["10Y (ann.) %"] = (
-        _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
-    )
+    metrics["10Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
 
-    metrics["All-time (ann.) %"] = _stats.cagr(df, 0.0, compounded, win_year) * pct
+    metrics["All-time (ann.) %"] = _stats.cagr(df, 0.0, compounded) * pct
 
     # best/worst
     if mode.lower() == "full":

--- a/quantstats_lumi/stats.py
+++ b/quantstats_lumi/stats.py
@@ -79,7 +79,7 @@ def distribution(returns, compounded=True, prepare_returns=True):
         else:
             returns = returns[returns.columns[0]]
 
-    apply_fnc = comp if compounded else 'sum'
+    apply_fnc = comp if compounded else "sum"
     daily = returns.dropna()
 
     if prepare_returns:
@@ -582,9 +582,9 @@ def gain_to_pain_ratio(returns, rf=0, resolution="D"):
     return returns.sum() / downside
 
 
-def cagr(returns, rf=0.0, compounded=True, periods=365):
+def cagr(returns, rf=0.0, compounded=True):
     """
-    Calculates the communicative annualized growth return
+    Calculates the cummulative annualized growth rate
     (CAGR%) of access returns
 
     If rf is non-zero, you must specify periods.
@@ -596,7 +596,7 @@ def cagr(returns, rf=0.0, compounded=True, periods=365):
     else:
         total = _np.sum(total, axis=0)
 
-    years = (returns.index[-1] - returns.index[0]).days / periods
+    years = (returns.index[-1] - returns.index[0]).days / 365
 
     res = abs(total + 1.0) ** (1.0 / years) - 1
 
@@ -616,7 +616,7 @@ def rar(returns, rf=0.0, periods=365):
     In this case, rf is assumed to be expressed in yearly (annualized) terms
     """
     returns = _utils._prepare_returns(returns, rf)
-    return cagr(returns=returns, periods=periods) / exposure(returns)
+    return cagr(returns=returns) / exposure(returns)
 
 
 def skew(returns, prepare_returns=True):
@@ -643,7 +643,7 @@ def calmar(returns, prepare_returns=True, periods=365):
     """Calculates the calmar ratio (CAGR% / MaxDD%)"""
     if prepare_returns:
         returns = _utils._prepare_returns(returns)
-    cagr_ratio = cagr(returns=returns, periods=periods)
+    cagr_ratio = cagr(returns=returns)
     max_dd = max_drawdown(returns)
     return cagr_ratio / abs(max_dd)
 
@@ -951,6 +951,7 @@ def kelly_criterion(returns, prepare_returns=True):
 
     return ((win_loss_ratio * win_prob) - lose_prob) / win_loss_ratio
 
+
 # Calculate the correlation to the benchmark
 def benchmark_correlation(returns, benchmark, prepare_returns=True):
     """Calculates the correlation to the benchmark"""
@@ -1181,4 +1182,4 @@ def romad(returns, periods=365, annualize=True, smart=False):
         * annualize: return annualize sharpe?
         * smart: return smart sharpe ratio
     """
-    return cagr(returns, periods=periods) / -max_drawdown(returns)
+    return cagr(returns) / -max_drawdown(returns)


### PR DESCRIPTION
CAGR is an **annualized** rate, so the cagr() function should figure out how many years go by between the first and last of the returns that are input to the function. To do this, we just figure out the number of days elapsed and divide by 365.

The current code takes a periods parameter and does some funny math that produces wrong results because the frequency (daily, weekly, monthly) of the returns is irrelevant for this function. 

This mistake is the cause of multiple open issues:

https://github.com/Lumiwealth/quantstats_lumi/issues/26#issuecomment-2494820483
https://github.com/Lumiwealth/quantstats_lumi/issues/30
https://github.com/Lumiwealth/quantstats_lumi/issues/44

This request is to use a constant 365 to calculate the number of years in cagr and remove the periods parameter only from this function.