### PR TITLE
fix UnicodeDecodeError in non "utf-8" jupyter environment

### DIFF
--- a/quantstats_lumi/reports.py
+++ b/quantstats_lumi/reports.py
@@ -123,7 +123,7 @@ def html(
     win_year, win_half_year = _get_trading_periods(periods_per_year)
 
     tpl = ""
-    with open(template_path or __file__[:-4] + ".html") as f:
+    with open(template_path or __file__[:-4] + ".html", encoding='utf-8') as f:
         tpl = f.read()
         f.close()
 


### PR DESCRIPTION
fix "UnicodeDecodeError: 'gbk' codec can't decode byte 0x92 in position 13459: illegal multibyte sequence"

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add UTF-8 encoding specification to the file open function in `quantstats_lumi/reports.py` to fix UnicodeDecodeError.

### Why are these changes being made?

This change is necessary because, without explicitly specifying the UTF-8 encoding, opening the file may lead to a `UnicodeDecodeError` in Jupyter environments that do not default to UTF-8. By specifying encoding, we ensure consistent behavior across different environments and prevent potential decoding issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->