### PR TITLE
Make quantstats_lumi work with ipython 9.x.x

### DIFF
--- a/quantstats_lumi/utils.py
+++ b/quantstats_lumi/utils.py
@@ -297,7 +297,7 @@ def _in_notebook(matplotlib_inline=False):
         if shell == "ZMQInteractiveShell":
             # Jupyter notebook or qtconsole
             if matplotlib_inline:
-                get_ipython().magic("matplotlib inline")
+                get_ipython().run_line_magic("matplotlib", "inline")
             return True
         if shell == "TerminalInteractiveShell":
             # Terminal running IPython


### PR DESCRIPTION
refactor(utils): update matplotlib magic command for Jupyter compatibility

- Replace deprecated `magic` method with `run_line_magic` for better Jupyter integration

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update `quantstats_lumi/utils.py` to use `get_ipython().run_line_magic()` instead of `get_ipython().magic()` for specifying "matplotlib inline" in Jupyter notebooks.

### Why are these changes being made?

This change addresses compatibility issues with IPython 9.x.x that prevent `magic()` from functioning as expected, ensuring that the library continues to provide inline plotting capabilities in newer Jupyter notebook environments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Updated the method for enabling inline plotting in Jupyter notebooks for improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->